### PR TITLE
Rename incorrect node

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -15,7 +15,7 @@
   (ident) @variable.parameter)
 (variable_decl
   (optionally_typed_ident (ident) @variable))
-(const_assert_statement) @variable
+(assert_statement) @variable
 
 ; Struct and struct members
 (struct_decl


### PR DESCRIPTION
There's no `const_assert_statement` node in `grammar.js`.

* queries/highlights.scm: Rename const_assert_statement to assert_statement.